### PR TITLE
✨ (#81) 챌린지 주제 (추가/목록/읽기/수정) 기능 개발

### DIFF
--- a/app/admin/_api/challengeTopicList.ts
+++ b/app/admin/_api/challengeTopicList.ts
@@ -1,0 +1,18 @@
+// 이건 데이터 내용대로 바꾸세요
+interface ChallengeTopicData {
+  id: string;
+  topic: string; // 주제 제목
+  createAt: Date; // 생성 날짜
+  startDate: Date; // 시작 날짜
+  endDate: Date; // 종료 날짜
+  adminId: string | null; // 사용자 UUID (외래 키, Foreign Key)
+}
+
+export const challengeTopicList = async () => {
+    const response = await fetch('/api/show-challenge-topic-list', {
+      method: 'GET',
+      headers: { "Content-Type": "application/json" },
+    });
+    const result: ChallengeTopicData[] = await response.json();
+    return result;
+}

--- a/app/admin/_api/createChallengeTopic.ts
+++ b/app/admin/_api/createChallengeTopic.ts
@@ -1,0 +1,35 @@
+import { ChallengeTopicDto } from "@/application/usecases/challenge/dto/ChallengeTopicDto";
+
+export const createChallengeTopic = async (receivedData: ChallengeTopicDto) => {
+  // startDate의 시간을 00:00:01로 설정
+  const formattedStartDate = receivedData.startDate
+    ? new Date(new Date(receivedData.startDate).getTime() + 1000).toISOString()
+    : null;
+
+  // endDate의 시간을 23:59:59로 설정
+  const formattedEndDate = receivedData.endDate
+    ? new Date(new Date(receivedData.endDate).getTime() + (23 * 60 * 60 * 1000) + (59 * 60 * 1000) + (59 * 1000)).toISOString()
+    : null;
+
+  // 서버로 전송할 데이터 변환
+  const challengeTopicData = {
+    ...receivedData,
+    startDate: formattedStartDate ? new Date(formattedStartDate).toISOString() : null,
+    endDate: formattedEndDate ? new Date(formattedEndDate).toISOString() : null,
+};
+
+  const response: Response = await fetch('/api/create-challenge-topic', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+
+    body: JSON.stringify(challengeTopicData),
+  });
+
+  const result = await response.json();
+
+  if (!response.ok) {
+    throw new Error(result.error || '챌린지 주제 생성 실패');
+  }
+
+  return result;
+};

--- a/app/admin/_api/showChallengeTopic.ts
+++ b/app/admin/_api/showChallengeTopic.ts
@@ -1,0 +1,15 @@
+import { ChallengeTopicDto } from "@/application/usecases/challenge/dto/ChallengeTopicDto";
+
+export const showChallengeTopic = async (challengeTopicId:string) => {
+    if (!challengeTopicId) {
+        throw new Error('challengeTopicId가 필요합니다.');
+    }
+
+    const response: Response = await fetch(`/api/show-challenge-topic/${challengeTopicId}`, {
+        method: 'GET',
+        headers: { "Content-Type": "application/json" },
+    });
+
+    const result: ChallengeTopicDto = await response.json();
+    return result;
+}

--- a/app/admin/_api/updateChallengeTopic.ts
+++ b/app/admin/_api/updateChallengeTopic.ts
@@ -1,0 +1,35 @@
+import { ChallengeTopicDto } from "@/application/usecases/challenge/dto/ChallengeTopicDto";
+
+export const updateChallengeTopic = async (
+    challengeTopicId: string, receivedData: ChallengeTopicDto
+) => {
+    // startDate의 시간을 00:00:01로 설정
+    const formattedStartDate = receivedData.startDate
+        ? new Date(new Date(receivedData.startDate).getTime() + 1000).toISOString()
+        : null;
+
+    // endDate의 시간을 23:59:59로 설정
+    const formattedEndDate = receivedData.endDate
+        ? new Date(new Date(receivedData.endDate).getTime() + (23 * 60 * 60 * 1000) + (59 * 60 * 1000) + (59 * 1000)).toISOString()
+        : null;
+
+    // 서버로 전송할 데이터 변환
+    const updateData = {
+        ...receivedData,
+        startDate: formattedStartDate ? new Date(formattedStartDate).toISOString() : null,
+        endDate: formattedEndDate ? new Date(formattedEndDate).toISOString() : null,
+    };
+
+    const response: Response = await fetch(`/api/update-challenge-topic/${challengeTopicId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+
+        body: JSON.stringify(updateData),
+    });
+
+    const result = await response.json();
+
+    if (!response.ok) {
+        throw new Error(result.error || '챌린지 주제 수정 실패');
+    }
+}

--- a/app/admin/topic/[topic-id]/edit/page.tsx
+++ b/app/admin/topic/[topic-id]/edit/page.tsx
@@ -4,25 +4,103 @@ import Button from '@/components/Buttons/Button';
 import styles from '../page.module.scss';
 import InputBox from '@/components/InputBox/InputBox/InputBox';
 import DatePicker from '@/components/InputBox/DatePicker/DatePicker';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { updateChallengeTopic } from '@/app/admin/_api/updateChallengeTopic';
+import ROUTES from '@/constants/routes';
+import Confirmation from '@/components/Confirmation/Confirmation';
+import { showChallengeTopic } from '@/app/admin/_api/showChallengeTopic';
+import { ChallengeTopic } from '@/domain/entities/ChallengeTopic';
 
 const TopicEdit: React.FC = () => {
-  /* 아이콘 비활성화 관련 설정 */
-  const [topic, setTopic] = useState('눈 내리는 겨울');
-  const [startDate, setStartDate] = useState('2025-01-01');
-  const [endDate, setEndDate] = useState('2025-01-15');
+  const params = useParams();
+  const challengeTopicId = params['topic-id'] as string;
 
-  // 입력값이 전부 비어있지 않으면 폼이 유효하다고 판단
+  // Next.js 라우터
+  const router = useRouter();
+  // 확인 팝업
+  const [submitPopupOpen, setSubmitPopupOpen] = useState(false);
+
+  /* 챌린지 주제 정보 받아오기 시작 */
+  const [challengeTopic, setChallengeTopic] = useState<ChallengeTopic | null>(null);
+  // fetch 여부를 통해 무한반복 로드 방지(매우 중요)
+  const [isFetching, setIsFetching] = useState(false);
+
+  useEffect(()=>{
+    // ✅ challengeTopicId가 없거나 이미 요청 중이면 실행 안 함 (isFetching 매우 중요)
+    if (!challengeTopicId || isFetching) return;
+
+    const fetchData = async () => {
+      try {
+        if (!challengeTopicId) {
+          console.error("🚨 Challenge Topic ID is missing.");
+          return;
+        }
+        const data = await showChallengeTopic(challengeTopicId);
+        setChallengeTopic(data);
+      } catch (error) {
+        console.error('🚨 챌린지 주제 불러오기 실패:', error);
+      } finally {
+        setIsFetching(false); // fetch 여부를 통해 무한반복 로드 방지(매우 중요)
+      }
+    };
+    fetchData();
+  }, [challengeTopicId, isFetching]); // isFetching을 deps에 안 넣으면 isFetching값이 useState 내에서 적용 안됨(→무한반복)
+  /* 챌린지 주제 정보 받아오기 끝 */
+
+  /* 아이콘 비활성화 관련 설정 */
+  const [topic, setTopic] = useState('');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+
+  // ✅ challengeTopic이 변경될 때 input 값 업데이트
+  useEffect(() => {
+    if (challengeTopic) {
+      // topic값이 없으면 빈 값('') 반환
+      setTopic(challengeTopic.topic || '');
+      // startDate 변환 (UTC 변환 없이 KST 00:00:01 적용 후 YYYY-MM-DD 반환)
+      setStartDate(
+        challengeTopic.startDate
+          ? `${new Date(challengeTopic.startDate).getFullYear()}-${String(new Date(challengeTopic.startDate).getMonth() + 1).padStart(2, '0')}-${String(new Date(challengeTopic.startDate).getDate()).padStart(2, '0')}`
+          : ''
+      );
+      // endDate 변환 (UTC 변환 없이 KST 23:59:59 적용 후 YYYY-MM-DD 반환)
+      setEndDate(
+        challengeTopic.endDate
+          ? `${new Date(challengeTopic.endDate).getFullYear()}-${String(new Date(challengeTopic.endDate).getMonth() + 1).padStart(2, '0')}-${String(new Date(challengeTopic.endDate).getDate()).padStart(2, '0')}`
+          : ''
+      );
+    }
+  }, [challengeTopic]);
+
+  // // 입력값이 전부 비어있지 않으면 폼이 유효하다고 판단
   const isFormValid = topic !== '' && startDate !== '' && endDate !== '';
   /* 아이콘 비활성화 관련 설정 */
 
+  /* 폼 입력 시작 */
+  const handleUpdateTopicChallenge = async () => {
+    const formData:any = { topic, startDate, endDate };
+    await updateChallengeTopic(challengeTopicId, formData);
+    router.push(ROUTES.admin.topic.detail.replace("[topic-id]", challengeTopicId));
+  }
+
   const handleSubmit = (event: React.FormEvent): void => {
     event.preventDefault();
-    // 폼 데이터 처리 로직 작성
-    console.log('Form submitted');
+    setSubmitPopupOpen(true);
   };
+  /* 폼 입력 끝 */
 
   return (
+    <>
+    {/* submitPopupOpen이 true일 때만 Confirmation 표시 */}
+    {submitPopupOpen && (
+      <Confirmation
+        text='수정하시겠습니까?'
+        opened={submitPopupOpen}
+        onClickConfirmation={handleUpdateTopicChallenge}
+        modalClose={() => setSubmitPopupOpen(false)}
+      />
+    )}
     <form className={styles.form} onSubmit={handleSubmit}>
       <h2 className={styles.pageTitle}>챌린지 수정</h2>
       <div className={styles.inputContainer}>
@@ -37,6 +115,7 @@ const TopicEdit: React.FC = () => {
         <Button icon='download' label='저장하기' onClickButton={handleSubmit} disabled={!isFormValid} />
       </div>
     </form>
+    </>
   );
 };
 

--- a/app/admin/topic/[topic-id]/page.tsx
+++ b/app/admin/topic/[topic-id]/page.tsx
@@ -4,10 +4,71 @@ import Button from '@/components/Buttons/Button';
 import styles from './page.module.scss';
 import InputBox from '@/components/InputBox/InputBox/InputBox';
 import DatePicker from '@/components/InputBox/DatePicker/DatePicker';
-import { useRouter } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { ChallengeTopic } from '@/domain/entities/ChallengeTopic';
+import { showChallengeTopic } from '../../_api/showChallengeTopic';
 
 const TopicView: React.FC = () => {
+  // param(challengeTopicId) 받아오기
+  const params = useParams();
+  const challengeTopicId = params['topic-id'] as string; // Type assertion을 이용해 string으로 변환
+
   const router = useRouter(); // onClick 또는 onClickEvent를 통한 페이지 이동에 필요
+
+  /* 챌린지 주제 정보 받아오기 시작 */
+  const [challengeTopic, setChallengeTopic] = useState<ChallengeTopic | null>(null);
+  // fetch 여부를 통해 무한반복 로드 방지(매우 중요)
+  const [isFetching, setIsFetching] = useState(false);
+  // form값 유효 검사
+  const [isFormValid, setIsFormValid] = useState(false);
+
+  useEffect(()=>{
+    // ✅ challengeTopicId가 없거나 이미 요청 중이면 실행 안 함 (isFetching 매우 중요)
+    if (!challengeTopicId || isFetching) return;
+
+    const fetchData = async () => {
+      try {
+        if (!challengeTopicId) {
+          console.error("🚨 Challenge Topic ID is missing.");
+          return;
+        }
+        const data = await showChallengeTopic(challengeTopicId);
+        if (!data) {
+          setIsFormValid(false);
+          return;
+        }
+        setChallengeTopic(data);
+        setIsFormValid(true);
+      } catch (error) {
+        console.error('🚨 챌린지 주제 불러오기 실패:', error);
+      } finally {
+        setIsFetching(false); // fetch 여부를 통해 무한반복 로드 방지(매우 중요)
+      }
+    };
+    fetchData();
+  }, [challengeTopicId, isFetching]); // isFetching을 deps에 안 넣으면 isFetching값이 useState 내에서 적용 안됨(→무한반복)
+  /* 챌린지 주제 정보 받아오기 끝 */
+
+  /* 날짜 시간 정상적으로 변환 시작 */
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+
+  useEffect(() => {
+    // startDate 변환 (UTC 변환 없이 KST 00:00:01 적용 후 YYYY-MM-DD 반환)
+    setStartDate(
+      challengeTopic?.startDate
+        ? `${new Date(challengeTopic.startDate).getFullYear()}-${String(new Date(challengeTopic.startDate).getMonth() + 1).padStart(2, '0')}-${String(new Date(challengeTopic.startDate).getDate()).padStart(2, '0')}`
+        : ''
+    );
+    // endDate 변환 (UTC 변환 없이 KST 23:59:59 적용 후 YYYY-MM-DD 반환)
+    setEndDate(
+      challengeTopic?.endDate
+        ? `${new Date(challengeTopic.endDate).getFullYear()}-${String(new Date(challengeTopic.endDate).getMonth() + 1).padStart(2, '0')}-${String(new Date(challengeTopic.endDate).getDate()).padStart(2, '0')}`
+        : ''
+    );
+  }, [challengeTopic]);
+  /* 날짜 시간 정상적으로 변환 끝 */
 
   const handleSubmit = (event: React.FormEvent): void => {
     event.preventDefault();
@@ -27,13 +88,13 @@ const TopicView: React.FC = () => {
       <div className={styles.inputContainer}>
         <h3 className={styles.title}>챌린지 주제 *</h3>
         <div>
-          <InputBox value='눈 내리는 겨울' placeholder='주제를 입력해 주세요.' readOnly={true} />
+          <InputBox value={challengeTopic?.topic} placeholder={isFormValid ? '주제를 입력해 주세요.' : '데이터를 불러올 수 없습니다.'} readOnly={true} />
         </div>
       </div>
-      <DatePicker value="2025-01-01" title='시작 날짜 *' placeholder="챌린지 시작 날짜를 선택하세요." readOnly={true} />
-      <DatePicker value="2025-01-15" title='종료 날짜 *' placeholder="챌린지 종료 날짜를 선택하세요." readOnly={true} />
+      <DatePicker value={startDate} title='시작 날짜 *' placeholder={isFormValid ? "챌린지 시작 날짜를 선택하세요." : "데이터를 불러올 수 없습니다."} readOnly={true} />
+      <DatePicker value={endDate} title='종료 날짜 *' placeholder={isFormValid ? "챌린지 종료 날짜를 선택하세요." : "데이터를 불러올 수 없습니다."} readOnly={true} />
       <div className={styles.saveButton}>
-        <Button icon='write' label='수정하기' onClickButton={handleMove} />
+        <Button icon='write' label='수정하기' onClickButton={handleMove} disabled={!isFormValid} />
       </div>
     </form>
   );

--- a/app/admin/topic/create/page.tsx
+++ b/app/admin/topic/create/page.tsx
@@ -5,8 +5,17 @@ import styles from './page.module.scss';
 import InputBox from '@/components/InputBox/InputBox/InputBox';
 import DatePicker from '@/components/InputBox/DatePicker/DatePicker';
 import { useState } from 'react';
+import { createChallengeTopic } from '../../_api/createChallengeTopic';
+import Confirmation from '@/components/Confirmation/Confirmation';
+import { useRouter } from 'next/navigation';
+import ROUTES from '@/constants/routes';
 
 const CreateTopic: React.FC = () => {
+  // Next.js 라우터
+  const router = useRouter();
+  // 확인 팝업
+  const [submitPopupOpen, setSubmitPopupOpen] = useState(false);
+
   /* 아이콘 비활성화 관련 설정 시작 */
   const [topic, setTopic] = useState('');
   const [startDate, setStartDate] = useState('');
@@ -16,13 +25,31 @@ const CreateTopic: React.FC = () => {
   const isFormValid = topic !== '' && startDate !== '' && endDate !== '';
   /* 아이콘 비활성화 관련 설정 끝 */
 
+  /* 폼 입력 시작 */
+  const handleCreateTopicChallenge = async () => {
+    const formData:any = { topic, startDate, endDate }
+    await createChallengeTopic(formData);
+    alert('✅ 챌린지 주제가 성공적으로 생성되었습니다.');
+    router.push(ROUTES.admin.nav);
+  }
+  
   const handleSubmit = (event: React.FormEvent): void => {
     event.preventDefault();
-    // 폼 데이터 처리 로직 작성
-    console.log('Form submitted');
+    setSubmitPopupOpen(true);
   };
+  /* 폼 입력 끝 */
 
   return (
+    <>
+    {/* submitPopupOpen이 true일 때만 Confirmation 표시 */}
+    {submitPopupOpen && (
+      <Confirmation
+        text='챌린지 주제를 생성하시겠습니까?'
+        opened={submitPopupOpen}
+        onClickConfirmation={handleCreateTopicChallenge}
+        modalClose={() => setSubmitPopupOpen(false)}
+      />
+    )}
     <form className={styles.form} onSubmit={handleSubmit}>
       <h2 className={styles.pageTitle}>새로운 챌린지 주제 생성</h2>
       <div className={styles.inputContainer}>
@@ -43,6 +70,7 @@ const CreateTopic: React.FC = () => {
         <Button icon='create' label='생성하기' onClickButton={handleSubmit} disabled={!isFormValid} />
       </div>
     </form>
+    </>
   );
 };
 

--- a/app/api/create-challenge-topic/route.ts
+++ b/app/api/create-challenge-topic/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createChallengeTopicUsecase } from "@/application/usecases/adminChallenge/CreateChallengeTopicUsecase";
+import { ChallengeTopicDto } from "@/application/usecases/challenge/dto/ChallengeTopicDto";
+import { ChallengeTopicRepository } from "@/domain/repositories/ChallengeTopicRepository";
+import { SbChallengeTopicRepository } from "@/infrastructure/repositories/SbChallengeTopicRepository";
+
+export async function POST(req: NextRequest) {
+    try {
+        // 요청 데이터 파싱
+        const data: ChallengeTopicDto = await req.json();
+        
+        const challengeTopicRepository: ChallengeTopicRepository =
+            new SbChallengeTopicRepository();
+        
+        // 챌린지 주제 생성 실행
+        await createChallengeTopicUsecase(challengeTopicRepository, data);
+
+        return NextResponse.json({ message: '챌린지 주제 생성 완료' }, { status: 200 });
+    } catch (error) {
+        console.error('🚨 챌린지 주제 생성 오류:', error);
+        return NextResponse.json({ error: '서버 오류 발생' }, { status: 500 });
+    }
+}

--- a/app/api/show-challenge-topic-list/route.ts
+++ b/app/api/show-challenge-topic-list/route.ts
@@ -1,0 +1,18 @@
+import { challengeTopicsListUsecase } from "@/application/usecases/adminChallenge/ChallengeTopicsListUsecase";
+import { SbChallengeTopicRepository } from "@/infrastructure/repositories/SbChallengeTopicRepository";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+    try {
+        const challengeTopicRepository = new SbChallengeTopicRepository();
+        const challengeTopicsList = await challengeTopicsListUsecase(challengeTopicRepository);
+
+        return NextResponse.json(challengeTopicsList, { status: 200 });
+    } catch (error: any) {
+        console.error('Error in /api/show-challenged-topic-list:', error);
+        return NextResponse.json(
+            { message: `Internal Server Error: ${error.message || error}` },
+            { status: 500 },
+        );
+    }
+}

--- a/app/api/show-challenge-topic/[challengeTopicId]/route.ts
+++ b/app/api/show-challenge-topic/[challengeTopicId]/route.ts
@@ -1,0 +1,28 @@
+import { showChallengeTopicUsecase } from "@/application/usecases/adminChallenge/ShowChallengeTopicUsecase";
+import { ChallengeTopicRepository } from "@/domain/repositories/ChallengeTopicRepository";
+import { SbChallengeTopicRepository } from "@/infrastructure/repositories/SbChallengeTopicRepository";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req:NextRequest) {
+    try {
+        // ✅ URL에서 challengeTopicId 추출
+        const { pathname } = new URL(req.url);
+        const challengeTopicId = pathname.split('/').pop(); // 마지막 경로(segment) 추출
+
+        // ✅ challengeTopicId가 없는 경우 예외 처리
+        if (!challengeTopicId || challengeTopicId === "undefined") {
+            return NextResponse.json({ message: "Missing challengeTopicId" }, { status: 400 });
+        }
+
+        const challengeTopicRepository: ChallengeTopicRepository = new SbChallengeTopicRepository();
+        const challengeTopic = await showChallengeTopicUsecase(challengeTopicRepository, challengeTopicId);
+
+        return NextResponse.json(challengeTopic, { status: 200 });
+    } catch (error: any) {
+        console.error('Error in /api/show-challenge-topic:', error);
+        return NextResponse.json(
+            { message: `Internal Server Error: ${error.message || error}` },
+            { status: 500 }
+        );
+    }
+}

--- a/app/api/update-challenge-topic/[challengeTopicId]/route.ts
+++ b/app/api/update-challenge-topic/[challengeTopicId]/route.ts
@@ -1,0 +1,36 @@
+import { SbChallengeTopicRepository } from "@/infrastructure/repositories/SbChallengeTopicRepository";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function PATCH(req: NextRequest) {
+    try {
+        // ✅ URL에서 challengeTopicId 추출
+        const { pathname } = new URL(req.url);
+        const challengeTopicId = pathname.split('/').pop(); // 마지막 경로(segment) 추출
+
+        if (!challengeTopicId) {
+            return NextResponse.json(
+                { error: 'challengeTopicId가 필요합니다.' },
+                { status: 400 },
+            );
+        }
+
+        const body = await req.json();
+
+        if (!body || Object.keys(body).length === 0) {
+            return NextResponse.json(
+                { error: '업데이트할 데이터가 필요합니다.' },
+                { status: 400 },
+            );
+        }
+
+        const challengeTopicRepository = new SbChallengeTopicRepository();
+        await challengeTopicRepository.updateChallengeTopic({ id: challengeTopicId, ...body });
+        return NextResponse.json({ status: 200 });
+    } catch (error: any) {
+        console.error('Error in /api/update-challenge-topic:', error);
+        return NextResponse.json(
+            { message: `Internal Server Error: ${error.message || error}` },
+            { status: 500 }
+        );
+    }
+}

--- a/application/usecases/adminChallenge/ChallengeTopicsListUsecase.ts
+++ b/application/usecases/adminChallenge/ChallengeTopicsListUsecase.ts
@@ -1,0 +1,10 @@
+import { SbChallengeTopicRepository } from "@/infrastructure/repositories/SbChallengeTopicRepository";
+import { ChallengeTopicDto } from "../challenge/dto/ChallengeTopicDto";
+
+export const challengeTopicsListUsecase = async (
+    ChallengeTopicRepository: SbChallengeTopicRepository
+):Promise<ChallengeTopicDto[]> => {
+    const challengeTopicsList = await ChallengeTopicRepository.findAll();
+
+    return challengeTopicsList;
+};

--- a/application/usecases/adminChallenge/CreateChallengeTopicUsecase.ts
+++ b/application/usecases/adminChallenge/CreateChallengeTopicUsecase.ts
@@ -1,0 +1,25 @@
+import { getUserIdFromSupabase } from "@/utils/supabase/getUserIdFromSupabase"
+import { ChallengeTopicRepository } from "@/domain/repositories/ChallengeTopicRepository";
+import { ChallengeTopic } from "@/domain/entities/ChallengeTopic";
+
+export const createChallengeTopicUsecase = async (
+    challengeTopicRepository: ChallengeTopicRepository,
+    data: ChallengeTopic
+): Promise<void> => {
+    // 현재 로그인된 관리자의 아이디 받아오기
+    const awaitAdminId = await getUserIdFromSupabase();
+    // adminId가 false일 경우 null로 처리
+    const adminId = awaitAdminId ? awaitAdminId : null;
+
+    // Dto를 인자로 받았고, 레포지토리에는 ChallengeTopic 엔티티의 형태로 전송해줘야 하기 때문에 변환해주기
+    // 없는건 null로 보내주면 됨
+    const newData: ChallengeTopic = {
+        id: null, // 기본 키 (Primary Key)
+        topic: data.topic, // 주제 제목
+        createAt: data.createAt, // 생성 날짜
+        startDate: data.startDate, // 시작 날짜
+        endDate: data.endDate, // 종료 날짜
+        adminId: adminId, // 사용자 UUID (외래 키, Foreign Key)
+    };
+    await challengeTopicRepository.createChallengeTopic(newData);
+}

--- a/application/usecases/adminChallenge/ShowChallengeTopicUsecase.ts
+++ b/application/usecases/adminChallenge/ShowChallengeTopicUsecase.ts
@@ -1,0 +1,10 @@
+import { SbChallengeTopicRepository } from "@/infrastructure/repositories/SbChallengeTopicRepository";
+import { ChallengeTopic } from "@/domain/entities/ChallengeTopic";
+
+export const showChallengeTopicUsecase = async (
+    ChallengeTopicRepository: SbChallengeTopicRepository,
+    challengeId: string
+):Promise<ChallengeTopic | null> => {
+    const challengeTopic = await ChallengeTopicRepository.findThisChallengeTopic(challengeId);
+    return challengeTopic;
+}

--- a/application/usecases/adminChallenge/UpdateChallengeTopicUsecase.ts
+++ b/application/usecases/adminChallenge/UpdateChallengeTopicUsecase.ts
@@ -1,0 +1,25 @@
+import { ChallengeTopic } from "@/domain/entities/ChallengeTopic";
+import { ChallengeTopicRepository } from "@/domain/repositories/ChallengeTopicRepository";
+import { getUserIdFromSupabase } from "@/utils/supabase/getUserIdFromSupabase";
+
+export const updateChallengeTopicUsecase = async (
+    challengeTopicRepository: ChallengeTopicRepository,
+    data: ChallengeTopic
+): Promise<void> => {
+    // 현재 로그인된 관리자의 아이디 받아오기
+    const awaitAdminId = await getUserIdFromSupabase();
+    // adminId가 false일 경우 null로 처리
+    const adminId = awaitAdminId ? awaitAdminId : null;
+
+    // Dto를 인자로 받았고, 레포지토리에는 ChallengeTopic 엔티티의 형태로 전송해줘야 하기 때문에 변환해주기
+    // 없는건 null로 보내주면 됨
+    const newData: ChallengeTopic = {
+        id: data.id, // 기본 키 (Primary Key)
+        topic: data.topic, // 주제 제목
+        createAt: data.createAt, // 생성 날짜
+        startDate: data.startDate, // 시작 날짜
+        endDate: data.endDate, // 종료 날짜
+        adminId: adminId, // 사용자 UUID (외래 키, Foreign Key)
+    };
+    await challengeTopicRepository.updateChallengeTopic(newData);
+}

--- a/application/usecases/challenge/dto/ChallengeTopicDto.ts
+++ b/application/usecases/challenge/dto/ChallengeTopicDto.ts
@@ -1,7 +1,7 @@
 type UUID = string;
 
 export interface ChallengeTopicDto {
-  id: UUID; // 기본 키 (Primary Key)
+  id: UUID | null; // 기본 키 (Primary Key)
   topic: string; // 주제 제목
   createAt: Date; // 생성 날짜
   startDate: Date; // 시작 날짜

--- a/domain/entities/ChallengeTopic.ts
+++ b/domain/entities/ChallengeTopic.ts
@@ -1,7 +1,7 @@
-type UUID = string;
+type UUID = string | null;
 
 export interface ChallengeTopic {
-  id: UUID; // 기본 키 (Primary Key)
+  id: UUID | null; // 기본 키 (Primary Key)
   topic: string; // 주제 제목
   createAt: Date; // 생성 날짜
   startDate: Date; // 시작 날짜

--- a/domain/repositories/ChallengeTopicRepository.ts
+++ b/domain/repositories/ChallengeTopicRepository.ts
@@ -1,6 +1,9 @@
 import { ChallengeTopic } from '../entities/ChallengeTopic';
 
 export interface ChallengeTopicRepository {
+  createChallengeTopic(data: ChallengeTopic): Promise<void>;
+  updateChallengeTopic(updateData: ChallengeTopic): Promise<void>;
   findAll(): Promise<ChallengeTopic[]>;
+  findThisChallengeTopic(topicId: string): Promise<ChallengeTopic | null>;
   findThisWeekChallengeTopic(): Promise<ChallengeTopic | null>;
 }

--- a/infrastructure/repositories/SbChallengeTopicRepository.ts
+++ b/infrastructure/repositories/SbChallengeTopicRepository.ts
@@ -3,6 +3,78 @@ import { ChallengeTopicRepository } from '@/domain/repositories/ChallengeTopicRe
 import { createClient } from '@/utils/supabase/server';
 
 export class SbChallengeTopicRepository implements ChallengeTopicRepository {
+  async createChallengeTopic(data: ChallengeTopic): Promise<void> {
+    const supabase = await createClient();
+    
+    // 입력받은 data를 DB에 저장하기 위해 스네이크케이스로 변환
+    const formattedData = {
+      topic: data.topic,
+      start_date: data.startDate, // 시작 날짜
+      end_date: data.endDate, // 종료 날짜
+      admin_id: data.adminId, // 관리자 UUID (외래 키, Foreign Key)
+    };
+    // null로 받은 애들은 그냥 안보내줘도 됨 (안보내주면 DB에서 자동으로 기본값을 사용해서 저장함)
+
+    const { error } = await supabase.from('challenge_topic').insert(formattedData).select();
+    if (error) {
+      throw new Error(error.message);
+    }
+  }
+
+  async updateChallengeTopic(updateData: ChallengeTopic): Promise<void> {
+    const supabase = await createClient();
+
+    if (!updateData.id) {
+      throw new Error('ID가 필요합니다.');
+    }
+
+    const formattedData = {
+      topic: updateData.topic,
+      start_date: updateData.startDate,
+      end_date: updateData.endDate,
+      admin_id: updateData.adminId,
+    }
+
+    console.log('Attempting to update challenge topic with ID:', updateData.id);  // 로그 추가
+    console.log('Formatted data to be updated:', formattedData);  // formattedData 로그 추가
+
+    // 먼저 해당 ID가 존재하는지 확인
+    const { data: existingTopic, error: fetchError } = await supabase
+        .from('challenge_topic')
+        .select('id')
+        .eq('id', updateData.id)
+        .single();  // 단일 레코드 반환
+
+    if (fetchError) {
+        console.error('Error fetching data:', fetchError);
+        throw new Error('ID가 존재하지 않거나 가져올 수 없습니다.');
+    }
+
+    if (!existingTopic) {
+        console.log('No record found with the given ID.');
+        throw new Error('주어진 ID로 레코드를 찾을 수 없습니다.');
+    }
+
+    // ID가 존재하면 업데이트
+    const { data, error } = await supabase
+        .from('challenge_topic')
+        .update(formattedData)
+        .eq('id', updateData.id);
+
+    console.log('Update query executed:', `UPDATE challenge_topic SET topic=${formattedData.topic}, start_date=${formattedData.start_date}, end_date=${formattedData.end_date}, admin_id=${formattedData.admin_id} WHERE id=${updateData.id}`);  // 쿼리 로그
+
+    // 결과 및 오류 확인
+    console.log('Update result:', data);  // 업데이트된 데이터 확인
+    console.log('Update error:', error);  // 에러 메시지 확인
+
+    if (error) {
+        console.error('Error updating data:', error);
+        throw new Error(error.message);
+    }
+
+    console.log('Update successful:', data);  // 최종적으로 업데이트된 데이터
+  }
+
   async findAll(): Promise<ChallengeTopic[]> {
     const supabase = await createClient();
     const { data, error } = await supabase
@@ -23,6 +95,32 @@ export class SbChallengeTopicRepository implements ChallengeTopicRepository {
       adminId: challengeTopic.admin_id,
     }));
     return formattedData || [];
+  }
+
+  async findThisChallengeTopic(topicId: string): Promise<ChallengeTopic | null> {
+    const supabase = await createClient();
+    const { data, error } = await supabase
+      .from('challenge_topic')
+      .select('*')
+      .eq('id', topicId)
+      .maybeSingle();
+
+      if (error) {
+        throw new Error(error.message);
+      }
+
+      if (!data) {
+        return null;
+      }
+
+      return {
+        id: data.id, // 기본 키 (Primary Key)
+        topic: data.topic, // 주제 제목
+        createAt: data.create_at, // 생성 날짜
+        startDate: data.start_date, // 시작 날짜
+        endDate: data.end_date, // 종료 날짜
+        adminId: data.admin_id // 사용자 UUID (외래 키, Foreign Key)
+      };
   }
 
   async findThisWeekChallengeTopic(): Promise<ChallengeTopic | null> {


### PR DESCRIPTION
- Admin 페이지에서 챌린지 주제를 관리하는 기능 개발
- Admin 페이지에서 챌린지 주제 리스트 확인(READ-list)
- 각 챌린지 id 페이지에서 챌린지 주제 정보 확인(READ)
- Admin 페이지에서 챌린지 주제 생성(CREATE)
- 각 챌린지 id 페이지에서 챌린지 주제 수정(UPDATE)
- 챌린지 주제 개별 읽기 기능 별도로 추가
- 메뉴바에서 키워드로 검색 가능
- 메뉴바의 정렬 기능 사용 가능(최신순/오름차순)
- 챌린지 주제의 삭제는 불가능하도록 방지