### PR TITLE
🔨 (#81) 프로필 페이지 추가사항 적용 및 에러 수정

### DIFF
--- a/app/(anon)/[pinId]/_api/checkPinUserId.ts
+++ b/app/(anon)/[pinId]/_api/checkPinUserId.ts
@@ -1,0 +1,31 @@
+interface CheckPinUserIdDto {
+  isOwner: boolean;
+  error?: string;
+}
+
+export const checkPinUserId = async (pinId: string): Promise<CheckPinUserIdDto> => {
+  try {
+    if (!pinId) {
+      console.error("🚨 checkPinUserId 호출 오류: pinId가 제공되지 않음");
+      return { isOwner: false, error: "pinId가 제공되지 않았습니다." };
+    }
+    
+    const response = await fetch('/api/check-pin-user-id', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ pinId }),
+    });
+
+    if (!response.ok) {
+      const errorMessage = `🚨 서버 오류: ${response.status} (${response.statusText})`;
+      console.error(errorMessage);
+      return { isOwner: false, error: errorMessage };
+    }
+
+    const result: CheckPinUserIdDto = await response.json();
+    return result;
+  } catch (error) {
+    console.error("🚨 핀 소유자 확인 API 호출 오류:", error);
+    return { isOwner: false, error: "서버 오류 발생" };
+  }
+}

--- a/app/(anon)/[pinId]/_components/ProfileSection.tsx
+++ b/app/(anon)/[pinId]/_components/ProfileSection.tsx
@@ -6,6 +6,8 @@ import HeartIconButton from '@/components/Buttons/HeartIconButton';
 import { deleteLike } from '../../like/_api/deleteLike';
 import { createLike } from '../../like/_api/createLike';
 import { useEffect, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import { checkPinUserId } from '../_api/checkPinUserId';
 
 interface ProfileProps {
   pinId: string;
@@ -17,8 +19,15 @@ interface ProfileProps {
 }
 
 const ProfileSection: React.FC<{ profile: ProfileProps }> = ({ profile }) => {
+  // ✅ URL에서 pinId 추출
+  const pathname = usePathname();
+  const pinId = pathname.split('/').pop(); // 마지막 경로(segment) 추출
+
   const [isliked, setIsliked] = useState(profile.isLiked);
   const [countlike, setCountlike] = useState(profile.countLike);
+
+  const [owner, setOwner] = useState<any | null>(null);
+
 
   useEffect(() => {
     setIsliked(profile.isLiked);
@@ -50,9 +59,24 @@ const ProfileSection: React.FC<{ profile: ProfileProps }> = ({ profile }) => {
     }
   };
 
+  // 본인 여부 boolean으로 확인(프로필 경로 설정)
+  useEffect(() => {
+    const fetchPinData = async () => {
+      const result = await checkPinUserId(pinId as string);
+
+      if (Array.isArray(result)) {
+        setOwner(result[0]); // ✅ 여러 개라면 첫 번째 요소 사용
+      } else {
+        setOwner(result); // ✅ 단일 객체라면 그대로 사용
+      }
+    };
+
+    fetchPinData();
+  }, [pinId]);
+
   return (
     <div className={styles.profileSection}>
-      <Link className={styles.profile} href={`profile/${profile.userId}`}>
+      <Link className={styles.profile} href={owner?.isOwn ? 'profile' : `profile/${profile.userId}`}>
         <span className={styles.profileImage}>
           <img src={profile.profileImg} alt='프로필 이미지' />
         </span>

--- a/app/(anon)/profile/[userId]/page.tsx
+++ b/app/(anon)/profile/[userId]/page.tsx
@@ -41,8 +41,13 @@ const UserProfile: React.FC = () => {
             nickname={userProfile?.nickname as string}
             email={userProfile?.email as string}
             profileImage={userProfile?.profileImg as string}
+            deleted={!!userProfile?.deleteDate}
         />
-        <UserPinList userId={userId} userName={userProfile?.nickname} />
+        <UserPinList
+          userId={userId}
+          userName={userProfile?.nickname}
+          deleted={!!userProfile?.deleteDate}
+        />
         </>
     );
 }

--- a/app/(anon)/profile/_api/showMyPinList.ts
+++ b/app/(anon)/profile/_api/showMyPinList.ts
@@ -2,10 +2,11 @@ import { PinDto } from '@/application/usecases/profile/dto/PinDto';
 
 export const showMyPinList = async (userId: string) => {
     const response: Response = await fetch('/api/show-my-pin-list', {
-        method: 'GET',
+        method: 'POST',
         headers: {
             'Content-Type': 'application/json',
-            'Authorization': `Bearer ${userId}`
+            'Authorization': `Bearer ${userId}`,
+            'body': JSON.stringify({}),
         }
     });
 

--- a/app/(anon)/profile/_components/MyPinList.tsx
+++ b/app/(anon)/profile/_components/MyPinList.tsx
@@ -72,6 +72,17 @@ const MyPinList = ({ userId }: { userId?: string }) => {
     .filter(([_, checked]) => checked)
     .map(([id]) => id);
 
+  /* 수정 기능 */
+  const handleEdit = () => {
+    setIsEditing((prev) => {
+      if (prev) {
+        // isEditing이 false가 될 경우 체크된 항목 초기화
+        setCheckedItems({});
+      }
+      return !prev;
+    });
+  };
+
   /* 삭제 기능 */
   const handleDelete = () => {
     setDeletePopupOpen(true);
@@ -137,7 +148,7 @@ const MyPinList = ({ userId }: { userId?: string }) => {
           {/* 편집/완료 버튼 */}
           <button
             className={`${styles.button} ${isEditing ? styles.complete : ''}`}
-            onClick={() => setIsEditing((prev) => !prev)}
+            onClick={handleEdit}
           >
             {isEditing ? '취소' : '편집'}
           </button>

--- a/app/(anon)/profile/_components/ProfileSummary.module.scss
+++ b/app/(anon)/profile/_components/ProfileSummary.module.scss
@@ -9,6 +9,10 @@
     -moz-column-gap: 12px;
     margin-bottom: $spacing-medium;
     border-bottom: $border-width-thin solid $main-black-3;
+
+    &.disabled {
+        opacity: 0.5;
+    }
 }
 
 .user_info {
@@ -17,6 +21,10 @@
         display: block;
         height: 24px;
         line-height: 24px;
+
+        .deleted {
+            display: inline-block;
+        }
 
         h1 {
             display: inline-block;

--- a/app/(anon)/profile/_components/ProfileSummary.tsx
+++ b/app/(anon)/profile/_components/ProfileSummary.tsx
@@ -3,13 +3,13 @@ import ProfileImage from "./ProfileImage";
 import styles from "./ProfileSummary.module.scss";
 
 type ProfileSummaryProps =
-    | { identified: true; onClick: () => void; id: string; nickname: string; email: string; profileImage?: string; }  // identified가 true일 때 onClick이 필수
-    | { identified?: false; onClick?: never; id: string; nickname: string; email: string; profileImage?: string; };  // identified가 false일 때 onClick은 선택
+    | { identified: true; onClick: () => void; id: string; nickname: string; email: string; profileImage?: string; deleted?: boolean; }  // identified가 true일 때 onClick이 필수
+    | { identified?: false; onClick?: never; id: string; nickname: string; email: string; profileImage?: string; deleted?: boolean; };  // identified가 false일 때 onClick은 선택
 
-const ProfileSummary: React.FC<ProfileSummaryProps> = ({ identified = false, onClick, id, nickname, email, profileImage }) => {
+const ProfileSummary: React.FC<ProfileSummaryProps> = ({ identified = false, onClick, id, nickname, email, profileImage, deleted }) => {
     return (
-        <div className={styles.profile_summary}>
-            <ProfileImage backgroundImage={profileImage} />
+        <div className={`${styles.profile_summary}${deleted ? ' '+styles.disabled : ''}`}>
+            <ProfileImage backgroundImage={deleted ? '/default-profile-img.jpg' : profileImage} />
             <div className={styles.user_info}>
                 {identified && onClick && (
                 <div className={styles.name} onClick={onClick} style={{cursor:'pointer'}}>
@@ -19,10 +19,10 @@ const ProfileSummary: React.FC<ProfileSummaryProps> = ({ identified = false, onC
                 )}
                 {!identified && (
                 <div className={styles.name}>
-                    <h1>{nickname}</h1>
+                    <h1>{deleted ? "탈퇴된 사용자입니다." : nickname}</h1>
                 </div>
                 )}
-                <span className={styles.email}>{email}</span>
+                {!deleted && <span className={styles.email}>{email}</span>} {/* deleted가 true이면 이메일 숨김 */}
             </div>
         </div>
     );

--- a/app/(anon)/profile/_components/UserPinList.tsx
+++ b/app/(anon)/profile/_components/UserPinList.tsx
@@ -1,26 +1,14 @@
 'use client';
 
-import ProfilePinCard from "@/components/Card/ProfilePinCard/ProfilePinCard";
 import styles from "./UserPinList.module.scss";
 import { useEffect, useState } from "react";
 import { showUserPinList } from "../_api/showUserPinList";
 import { deleteLike } from "../../like/_api/deleteLike";
 import { createLike } from "../../like/_api/createLike";
-// import { PinDto } from "@/application/usecases/profile/dto/PinDto";
+import PinCard from "@/components/Card/PinCard/PinCard";
+import { PinDto } from "@/application/usecases/profile/dto/PinDto";
 
-interface PinDto {
-  userId: string,
-  userName: string,
-  userEmail: string,
-  id: string,
-  placeName: string,
-  address: string, // 두 단어만 유지
-  image: string,
-  isLiked: boolean,
-  countLike: number
-}
-
-const UserPinList = ({ userId, userName }: { userId?: string; userName?: string }) => {
+const UserPinList = ({ userId, userName, deleted }: { userId?: string; userName?: string, deleted?: boolean }) => {
     const [list, setList] = useState<PinDto[]>([]);
 
     /* .container 스타일 설정(휴지통 아이콘 고정에 필요) */
@@ -30,25 +18,19 @@ const UserPinList = ({ userId, userName }: { userId?: string; userName?: string 
             (container as HTMLElement).style.position = 'relative';
         }
     }, []);
-    
-    /* 핀 리스트 불러오기 */
-    useEffect(()=>{
-        const fetchData = async () => {
-            // userId가 undefined거나 null일 경우 실행하지 않고 다시 돌아감
-            if (!userId || userId.trim() === "") return;
 
-            try {
-                if (!userId) {
-                    console.error("🚨 User ID is missing.");
-                    return;
-                }
-                const data = await showUserPinList(userId); // userId 전달
-                setList(data);
-            } catch (error) {
-                console.error('🚨 핀 데이터 불러오기 실패:', error);
-            }
-        };
-        fetchData();
+    /* 핀 리스트 불러오기 */
+    useEffect(() => {
+      if (!userId) return;
+      const fetchData = async () => {
+        try {
+          const data = await showUserPinList(userId);
+          setList(data);
+        } catch (error) {
+          console.error('🚨 핀 데이터 불러오기 실패:', error);
+        }
+      };
+      fetchData();
     }, [userId]);
 
     // 핀의 좋아요 상태 변경하는 함수
@@ -59,7 +41,7 @@ const UserPinList = ({ userId, userName }: { userId?: string; userName?: string 
     ) => {
       e.preventDefault();
       e.stopPropagation();
-    
+
       // Supabase에 좋아요 상태 업데이트
       try {
         if (isLiked) {
@@ -81,15 +63,16 @@ const UserPinList = ({ userId, userName }: { userId?: string; userName?: string 
         <>
         <div className={styles.mypin_list}>
             <div className={styles.head}>
-                <h1 className={styles.title}>{userName}님이 올린 핀</h1>
+                <h1 className={styles.title}>{deleted ? '탈퇴된 사용자' : userName}님이 올린 핀</h1>
             </div>
             
             {/* ✅ 기존의 ul > li 구조를 div.pincard_container 내부에 배치 */}
             <div className={styles.pincard_container}>
             {list.length > 0 ? (
                 list.map((pin) => (
-                <ProfilePinCard
+                <PinCard
                     key={pin.id} // ✅ key를 여기서 사용
+                    alt={pin.placeName}
                     id={pin.id}
                     url={pin.image}
                     location={pin.placeName}

--- a/app/api/check-pin-user-id/route.ts
+++ b/app/api/check-pin-user-id/route.ts
@@ -1,0 +1,24 @@
+import { checkPinUserIdUsecase } from "@/application/usecases/pin/CheckPinUserIdUsecase";
+import { SbPinRepository } from "@/infrastructure/repositories/SbPinRepository";
+import { SbUserRepository } from "@/infrastructure/repositories/SbUserRepository";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest) {
+    try {
+        // 리포지토리 초기화
+        const pinRepository = new SbPinRepository();
+        const userRepository = new SbUserRepository();
+
+        // request에서 pinId 가져오기
+        const { pinId } = await req.json();
+
+        // checkPinUserId 실행
+        const data = await checkPinUserIdUsecase(pinRepository, userRepository, pinId);
+
+        // ✅ JSON 응답 반환
+        return NextResponse.json({ isOwn: data }, { status: 200 });
+    } catch (error) {
+        console.error("🚨 유저 아이디 조회 오류:", error);
+        return NextResponse.json({ error: '서버 오류 발생' }, { status: 500 });
+    }
+}

--- a/app/api/create-like/route.ts
+++ b/app/api/create-like/route.ts
@@ -13,8 +13,6 @@ export async function POST(req: NextRequest) {
 
     await createLikeUsecase(likeRepository, data);
 
-    console.log(data);
-
     return NextResponse.json({ message: '좋아요 생성 완료' }, { status: 201 });
   } catch (error) {
     console.error('좋아요 생성 오류:', error);

--- a/app/api/show-my-pin-list/route.ts
+++ b/app/api/show-my-pin-list/route.ts
@@ -5,7 +5,7 @@ import { myPinListUsecase } from '@/application/usecases/profile/MyPinListUsecas
 import { SbLikeRepository } from '@/infrastructure/repositories/SbLikeRepository';
 
 // GET 요청 핸들러
-export async function GET(req: NextRequest) {
+export async function POST(req: NextRequest) {
   try {
     // 헤더에서 userId 추출
     const authHeader = req.headers.get('Authorization');

--- a/app/api/show-user-pin-list/route.ts
+++ b/app/api/show-user-pin-list/route.ts
@@ -15,16 +15,17 @@ export async function POST(req: NextRequest) {
 
     //base64로 인코딩된 userId 디코딩
     const decodedUserId = Buffer.from(userId, 'base64').toString('utf-8');
-
-    // const userId = await req.json();
     
-    // console.log(userId.id);
     // 리포지토리 초기화
     const pinRepository = new SbPinRepository();
     const userRepository = new SbUserRepository();
 
     // 핀 리스트 가져오기
-    const pins = await userPinListUsecase(pinRepository, userRepository, decodedUserId);
+    const pins = await userPinListUsecase(
+      pinRepository,
+      userRepository,
+      decodedUserId,
+    );
 
     return NextResponse.json(pins, { status: 200 });
   } catch (error) {

--- a/application/usecases/like/CreateLikeUsecase.ts
+++ b/application/usecases/like/CreateLikeUsecase.ts
@@ -10,6 +10,10 @@ export const createLikeUsecase = async (
   // 현재 로그인된 사용자의 아이디 받아오기
   const userId = await getUserIdFromSupabase();
 
+  if (!userId) {
+    throw new Error("User is not logged in");
+  }
+
   // Dto를 인자로 받았고, 레포지토리에는 Pin엔티티의 형태로 전송해줘야 하기 때문에 변환해주기
   // 없는건 걍 null로 보내주면 됨
   const newData: Like = {
@@ -18,5 +22,10 @@ export const createLikeUsecase = async (
     createdAt: null,
   };
 
-  await likeRepository.createLike(newData);
+  try {
+    await likeRepository.createLike(newData);
+    console.log("Like created successfully");
+  } catch (error) {
+    console.error("Error creating like:", error);
+  }
 };

--- a/application/usecases/pin/CheckPinUserIdUsecase.ts
+++ b/application/usecases/pin/CheckPinUserIdUsecase.ts
@@ -1,0 +1,36 @@
+import { PinRepository } from "@/domain/repositories/PinRepository";
+import { UserRepository } from "@/domain/repositories/UserRepository";
+import { getUserIdFromSupabase } from "@/utils/supabase/getUserIdFromSupabase";
+
+export const checkPinUserIdUsecase = async (
+    pinRepository: PinRepository,
+    userRepository: UserRepository,
+    pinId: string,
+): Promise<boolean | null> => {
+    const userId = await getUserIdFromSupabase();
+
+    if (!userId) {
+        return false; // 로그인된 사용자 ID가 없으면 false 반환
+    }
+
+    // ✅ pinId에 해당하는 핀 가져오기 (배열 형태 가능)
+    const pins = await pinRepository.getPinById(pinId);
+    if (!pins) {
+        console.error(`🚨 핀을 찾을 수 없음: pinId=${pinId}`);
+        return null; // ✅ 핀이 존재하지 않으면 null 반환
+    }
+
+    // ✅ 첫 번째 핀만 선택하여 소유자 ID 확인
+    const pin = Array.isArray(pins) ? pins[0] : pins; // ✅ 배열이면 첫 번째 요소 선택
+
+    // ✅ 핀을 생성한 사용자 ID 가져오기
+    const loggedInUser = await userRepository.getUserById(pin.userId);
+    
+    if (!loggedInUser || !loggedInUser.id) {
+        console.error(`🚨 핀의 소유자 정보를 찾을 수 없음: pinId=${pinId}, userId=${pin.userId}`);
+        return false;
+    }
+    
+    // ✅ 현재 로그인한 userId와 핀 소유자의 loggedInId 비교
+    return userId === loggedInUser.id;
+}

--- a/application/usecases/profile/UserPinListUsecase.ts
+++ b/application/usecases/profile/UserPinListUsecase.ts
@@ -1,6 +1,8 @@
 import { PinRepository } from "@/domain/repositories/PinRepository";
 import { UserRepository } from "@/domain/repositories/UserRepository";
 import { PinDto } from "./dto/PinDto";
+import { SbLikeRepository } from "@/infrastructure/repositories/SbLikeRepository";
+import { getUserIdFromSupabase } from "@/utils/supabase/getUserIdFromSupabase";
 
 // 주소에서 두 단어만 추출하는 함수
 const extractTwoWords = (address: string): string => {
@@ -15,6 +17,8 @@ export const userPinListUsecase = async (
 ): Promise<PinDto[] | null> => {
     //prop으로 전달받은 userId로 사용자 데이터 받아옴
     const userData = await userRepository.getUserById(userId);
+    //현재 로그인된 유저의 아이디를 getUserIdFromSupabase로 받아옴
+    const loggedInUserId = await getUserIdFromSupabase();
 
     // userId가 null인 경우 처리
     if (!userId) {
@@ -24,8 +28,15 @@ export const userPinListUsecase = async (
     // 모든 핀 리스트 가져오기
     const pins = await pinRepository.findPinsByUserId(userId);
 
+    // 모든 좋아요 데이터 가져오기
+    const likeRepository = new SbLikeRepository();
+    const likes = await likeRepository.showLike();
+
     // 각 핀의 좋아요 여부 확인 및 주소 가공
     const pinList = pins.map((pin) => {
+      const isLiked = loggedInUserId
+        ? likes.some((like) => like.pinId === pin.id && like.userId === loggedInUserId)
+        : false; // loggedInUserId가 없으면 isLiked는 항상 false이도록
       return {
         userId: userId,
         userName: userData.nickname, // userName 추가
@@ -34,6 +45,8 @@ export const userPinListUsecase = async (
         placeName: pin.placeName,
         address: extractTwoWords(pin.address), // 두 단어만 유지
         image: pin.image,
+        isLiked: isLiked,
+        countLike: pin.countLike || 0,
       };
     });
 

--- a/application/usecases/profile/dto/PinDto.ts
+++ b/application/usecases/profile/dto/PinDto.ts
@@ -1,11 +1,11 @@
 export interface PinDto {
-  userId: string;
-  userName: string;
-  userEmail: string;
-  id: string;
-  placeName: string;
-  address: string; // 두 단어만 유지
-  image: string;
-  isLiked: boolean;
+  userId: string,
+  userName: string,
+  userEmail: string,
+  id: string,
+  placeName: string,
+  address: string, // 두 단어만 유지
+  image: string,
+  isLiked: boolean,
   countLike: number | 0;
 }


### PR DESCRIPTION
- [🐛] 다른 유저의 프로필의 핀에 대한 '좋아요'가 토글되지 않는 문제 수정
- [🐛] 프로필에서 '편집' 버튼을 누르고 '취소' 버튼을 누르면 체크되었던 항목들이 리셋되도록 수정
- [🔨] 핀 상세보기 중 사용자 닉네임이 자기 자신일 경우 '/profile/[profile-id]'가 아닌 '/profile'로 리다이렉트
- [✅] 핀 상세보기 중 다른 유저가 올린 핀에 '...'(수정/삭제 표시) 아이콘이 표시되지 않아야 함
- [🔨] 프로필 정보 중 탈퇴된 계정의 프로필일 경우 보여지는 내용 수정